### PR TITLE
Export serialized type

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -38,6 +38,7 @@ Added in v0.1.0
 
 - [utils](#utils)
   - [Member (interface)](#member-interface)
+  - [Serialized (type alias)](#serialized-type-alias)
   - [Sum (interface)](#sum-interface)
   - [\_](#_)
   - [create](#create)
@@ -72,6 +73,19 @@ type Weather = Member<'Sun'> | Member<'Rain', number>
 ```
 
 Added in v0.1.0
+
+## Serialized (type alias)
+
+The serialized representation of a sum type, isomorphic to the sum type
+itself.
+
+**Signature**
+
+```ts
+export type Serialized<A> = A extends AnyMember ? readonly [Tag<A>, Value<A>] : never
+```
+
+Added in v0.1.1
 
 ## Sum (interface)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,10 +249,15 @@ export const create = <A extends AnyMember>(): Sum<A> => ({
 })
 
 /**
- * A serialized representation of our sum type, isomorphic to the sum type
- * itself. The conditional type distributes over the union members.
+ * The serialized representation of a sum type, isomorphic to the sum type
+ * itself.
+ *
+ * @since 0.1.1
  */
-type Serialized<A> = A extends AnyMember ? readonly [Tag<A>, Value<A>] : never
+// The conditional type distributes over the union members.
+export type Serialized<A> = A extends AnyMember
+  ? readonly [Tag<A>, Value<A>]
+  : never
 
 /**
  * Serialize any sum type member into a tuple of its discriminant tag and its


### PR DESCRIPTION
This type has needed to be reconstructed in both bindings libraries, and now there's a use case for it in web. There's no reason not to expose it, it's a public interface via the serialization functions.

I'll release 0.1.1 once this is merged.