### PR TITLE
`undefined` -> `null`

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -58,7 +58,7 @@ members.
 **Signature**
 
 ```ts
-export interface Member<K extends string = never, A = undefined> {
+export interface Member<K extends string = never, A = null> {
   readonly [tagKey]: K
   readonly [valueKey]: A
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ type ValueKey = typeof valueKey
  *
  * @since 0.1.0
  */
-export interface Member<K extends string = never, A = undefined> {
+export interface Member<K extends string = never, A = null> {
   readonly [tagKey]: K
   readonly [valueKey]: A
 }
@@ -72,7 +72,7 @@ type Value<A extends AnyMember> = A[ValueKey]
  * @internal
  */
 // eslint-disable-next-line functional/prefer-readonly-type
-export type Constructor<A extends AnyMember, B> = [B] extends [undefined]
+export type Constructor<A extends AnyMember, B> = [B] extends [null]
   ? () => A
   : (x: B) => A
 

--- a/test/type/index.ts
+++ b/test/type/index.ts
@@ -29,7 +29,7 @@ matchW({ C1: () => 123, C2: () => "hello" })
 // $ExpectType (x: string | number) => AnyMember
 type Test1 = Constructor<AnyMember, string | number>
 // $ExpectType () => AnyMember
-type Test2 = Constructor<AnyMember, undefined>
+type Test2 = Constructor<AnyMember, null>
 
 type D = Member<"C1", string> | Member<"C2", number> | Member<"C3">
 


### PR DESCRIPTION
Changes the internal type of nullary members to `null` for cheap JSON interop (post-serialisation).