### PR TITLE
Non-function nullary constructors

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -156,8 +156,8 @@ const getSun = Weather.match({
   [_]: () => 'no sun',
 })
 
-assert.strictEqual(getSun(Weather.mk.Sun()), 'sun')
-assert.strictEqual(getSun(Weather.mk.Clouds()), 'no sun')
+assert.strictEqual(getSun(Weather.mk.Sun), 'sun')
+assert.strictEqual(getSun(Weather.mk.Clouds), 'no sun')
 ```
 
 Added in v0.1.0

--- a/test/type/index.ts
+++ b/test/type/index.ts
@@ -1,12 +1,6 @@
 /* eslint-disable functional/functional-parameters, functional/no-expression-statement, @typescript-eslint/no-unused-vars */
 
-import {
-  create,
-  Member,
-  mkConstructor,
-  Constructor,
-  AnyMember,
-} from "../../src/index"
+import { create, Member, mkConstructor } from "../../src/index"
 
 //# constructors don't distribute over union input
 type A = Member<"A1", string | number>
@@ -26,11 +20,6 @@ const { matchW } = create<C>()
 // $ExpectType (x: C) => string | number
 matchW({ C1: () => 123, C2: () => "hello" })
 
-// $ExpectType (x: string | number) => AnyMember
-type Test1 = Constructor<AnyMember, string | number>
-// $ExpectType () => AnyMember
-type Test2 = Constructor<AnyMember, null>
-
 type D = Member<"C1", string> | Member<"C2", number> | Member<"C3">
 
 // $ExpectType (x: string) => D
@@ -39,5 +28,5 @@ const constructor1 = mkConstructor<D>()("C1")
 // $ExpectType (x: number) => D
 const constructor2 = mkConstructor<D>()("C2")
 
-// $ExpectType () => D
+// $ExpectType D
 const constructor3 = mkConstructor<D>()("C3")

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -5,6 +5,20 @@ import fc from "fast-check"
 
 describe("index", () => {
   describe("create", () => {
+    describe("constructors", () => {
+      it("are typesafe", () => {
+        type Sum = Member<"Nullary">
+        const Sum = create<Sum>()
+
+        // The relevance of `withFoo` is function subtyping.
+        const withFoo = <A>(f: (x: string) => A): A => f("foo")
+        const sum = withFoo(Sum.mk.Nullary)
+
+        const [, v] = serialize(sum)
+        expect(v).toBe(null)
+      })
+    })
+
     describe("pattern match function", () => {
       it("can pattern match", () => {
         type Weather =

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -5,20 +5,6 @@ import fc from "fast-check"
 
 describe("index", () => {
   describe("create", () => {
-    describe("constructors", () => {
-      it("are typesafe", () => {
-        type Sum = Member<"Nullary">
-        const Sum = create<Sum>()
-
-        // The relevance of `withFoo` is function subtyping.
-        const withFoo = <A>(f: (x: string) => A): A => f("foo")
-        const sum = withFoo(Sum.mk.Nullary)
-
-        const [, v] = serialize(sum)
-        expect(v).toBe(null)
-      })
-    })
-
     describe("pattern match function", () => {
       it("can pattern match", () => {
         type Weather =
@@ -37,7 +23,7 @@ describe("index", () => {
           ),
         )
 
-        expect(f(Weather.mk.Sun())).toBe("not rain")
+        expect(f(Weather.mk.Sun)).toBe("not rain")
       })
     })
   })
@@ -47,7 +33,7 @@ describe("index", () => {
       type Sum = Member<"foo"> | Member<"bar", undefined>
       const Sum = create<Sum>()
 
-      expect(serialize(Sum.mk.foo())).toEqual(["foo", null])
+      expect(serialize(Sum.mk.foo)).toEqual(["foo", null])
       expect(serialize(Sum.mk.bar(undefined))).toEqual(["bar", undefined])
     })
 


### PR DESCRIPTION
Fixes #44. This is the "some more exotic approach" alluded to at the end there.

This changes the library API as follows:

```ts
type Weather = Sum.Member<'Sun'> | Sum.Member<'Rain', number>
const Weather = Sum.create<Weather>()

// Before
Weather.mk.Sun()
Weather.mk.Rain(123)

// After
Weather.mk.Sun // <- no function call!
Weather.mk.Rain(123)
```