### PR TITLE
Export more stuff

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -175,11 +175,17 @@ type ReturnTypes<
   A extends Record<any, (...xs: ReadonlyArray<any>) => unknown>,
 > = ReturnType<A[keyof A]>
 
-type MatchW<A extends AnyMember> = <B extends Cases<A, unknown>>(
+/**
+ * @internal
+ */
+export type MatchW<A extends AnyMember> = <B extends Cases<A, unknown>>(
   fs: B,
 ) => (x: A) => ReturnTypes<B>
 
-type Match<A extends AnyMember> = <B>(fs: Cases<A, B>) => (x: A) => B
+/**
+ * @internal
+ */
+export type Match<A extends AnyMember> = <B>(fs: Cases<A, B>) => (x: A) => B
 
 const mkMatchW =
   <A extends AnyMember>(): MatchW<A> => // eslint-disable-line functional/functional-parameters


### PR DESCRIPTION
Without these exports, this errors when the `declaration` compiler option is enabled:

```ts
import * as Sum from 'shared/facades/Sum';

export type Mode = Sum.Member<'SubmitToBrief'> | Sum.Member<'Publish'>;
export const {
  mk,
  // Exported variable 'match' has or is using name '_' from external module "/Users/oliverash/Development/unsplash/unsplash-web/node_modules/@unsplash/sum-types/dist/types/index" but cannot be named.ts(4023)
  match,
  // Exported variable 'matchW' has or is using name '_' from external module "/Users/oliverash/Development/unsplash/unsplash-web/node_modules/@unsplash/sum-types/dist/types/index" but cannot be named.ts(4023)
  matchW,
} = Sum.create<Mode>();

```
