### PR TITLE
Maintain referential equality of constructors

### DIFF
--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -20,6 +20,18 @@ describe("index", () => {
       })
     })
 
+    describe("members", () => {
+      it("are value-equal", () => {
+        type Weather = Member<"Sun"> | Member<"Rain", number>
+        const Weather = create<Weather>()
+
+        expect(Weather.mk.Sun).toEqual(Weather.mk.Sun)
+        expect(Weather.mk.Sun).not.toEqual(Weather.mk.Rain(123))
+        expect(Weather.mk.Rain(123)).toEqual(Weather.mk.Rain(123))
+        expect(Weather.mk.Rain(123)).not.toEqual(Weather.mk.Rain(456))
+      })
+    })
+
     describe("pattern match function", () => {
       it("can pattern match", () => {
         type Weather =

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -5,6 +5,21 @@ import fc from "fast-check"
 
 describe("index", () => {
   describe("create", () => {
+    describe("constructors", () => {
+      it("are reference-equal", () => {
+        type Weather = Member<"Sun"> | Member<"Rain", number> | Member<"Snow">
+        const Weather = create<Weather>()
+
+        expect(Weather.mk.Sun).toEqual(Weather.mk.Sun)
+        expect(Weather.mk.Sun).not.toEqual(Weather.mk.Snow)
+        expect(Weather.mk.Sun).not.toEqual(Weather.mk.Rain)
+        expect(Weather.mk.Rain).toEqual(Weather.mk.Rain)
+
+        expect({ foo: Weather.mk.Sun }).toEqual({ foo: Weather.mk.Sun })
+        expect({ foo: Weather.mk.Sun }).not.toEqual({ foo: Weather.mk.Snow })
+      })
+    })
+
     describe("pattern match function", () => {
       it("can pattern match", () => {
         type Weather =


### PR DESCRIPTION
This improves interop with Jest (I think via the behaviour of `Object.is`), fixing #35.

The output from `toEqual` when the sums don't match is still unhelpful in the nullary case stating "serializes to the same string". This would probably require a custom matcher to resolve; in any case that can be addressed separately.