### PR TITLE
Add refinement primitive

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -43,6 +43,7 @@ Added in v0.1.0
   - [\_](#_)
   - [create](#create)
   - [deserialize](#deserialize)
+  - [is](#is)
   - [serialize](#serialize)
 
 ---
@@ -204,6 +205,34 @@ export declare const deserialize: <A extends AnyMember>() => (x: Serialized<A>) 
 ```
 
 Added in v0.1.0
+
+## is
+
+Refine a foreign value to a sum type member given its key and a refinement to
+its value.
+
+This is a low-level primitive. Instead consider `@unsplash/sum-types-io-ts`.
+
+**Signature**
+
+```ts
+export declare const is: <A extends AnyMember>() => <B extends Tag<A>>(
+  k: B
+) => (f: (mv: unknown) => mv is Value<Extract<A, Member<B, unknown>>>) => (x: unknown) => x is A
+```
+
+**Example**
+
+```ts
+import { Member, create, is } from '@unsplash/sum-types'
+
+type Weather = Member<'Sun'> | Member<'Rain', number>
+const Weather = create<Weather>()
+
+assert.strictEqual(is<Weather>()('Rain')((x): x is number => typeof x === 'number')(Weather.mk.Rain(123)), true)
+```
+
+Added in v0.4.0
 
 ## serialize
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,3 +335,44 @@ export const deserialize =
   <A extends AnyMember>() => // eslint-disable-line functional/functional-parameters
   (x: Serialized<A>): A =>
     ({ [tagKey]: x[0], [valueKey]: x[1] } as unknown as A)
+
+/**
+ * Refine a foreign value to a sum type member given its key and a refinement to
+ * its value.
+ *
+ * This is a low-level primitive. Instead consider `@unsplash/sum-types-io-ts`.
+ *
+ * @example
+ * import { Member, create, is } from "@unsplash/sum-types"
+ *
+ * type Weather
+ *   = Member<"Sun">
+ *   | Member<"Rain", number>
+ * const Weather = create<Weather>()
+ *
+ * assert.strictEqual(
+ *   is<Weather>()("Rain")((x): x is number => typeof x === 'number')(Weather.mk.Rain(123)),
+ *   true,
+ * )
+ *
+ * @since 0.4.0
+ */
+export const is =
+  <A extends AnyMember>() => // eslint-disable-line functional/functional-parameters
+  <B extends Tag<A>>(k: B) =>
+  (f: (mv: unknown) => mv is ValueByTag<A, B>) =>
+  (x: unknown): x is A => {
+    // eslint-disable-next-line functional/no-conditional-statement
+    if (x === null || !["object", "function"].includes(typeof x)) return false
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const xx: any = x
+
+    // eslint-disable-next-line functional/no-conditional-statement, @typescript-eslint/no-unsafe-member-access
+    if (!(tagKey in xx) || xx[tagKey] !== k) return false
+
+    // eslint-disable-next-line functional/no-conditional-statement, @typescript-eslint/no-unsafe-member-access
+    if (!(valueKey in xx) || !f(xx[valueKey])) return false
+
+    return true
+  }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,10 @@ export type AnyMember = Member<string, unknown>
 type Tag<A extends AnyMember> = A[TagKey]
 type Value<A extends AnyMember> = A[ValueKey]
 
+type ValueByTag<A extends AnyMember, K extends Tag<A>> = Value<
+  Extract<A, Member<K, unknown>>
+>
+
 /**
  * A constructor is either `A -> B` or, if it's nullary, directly `B`.
  *
@@ -78,7 +82,7 @@ type Value<A extends AnyMember> = A[ValueKey]
 export type Constructor<
   A extends AnyMember,
   K extends Tag<A>,
-  V = Value<Extract<A, Member<K, unknown>>>,
+  V = ValueByTag<A, K>,
   // eslint-disable-next-line functional/prefer-readonly-type
 > = [V] extends [null] ? A : (x: V) => A
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -357,6 +357,12 @@ export const deserialize =
  *
  * @since 0.4.0
  */
+// This needs to be thunked because:
+//   1. We want to enforce that `A` is provided, which to do with multiple type
+//      arguments would require `= never`.
+//   2. We want `B` to be inferred from the argument, which necessitates not
+//      being provided a default type (`=`). However, it would have to have a
+//      default type in order to follow `A`, which would itself have one.
 export const is =
   <A extends AnyMember>() => // eslint-disable-line functional/functional-parameters
   <B extends Tag<A>>(k: B) =>

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable functional/functional-parameters */
 
-import { create, _, serialize, deserialize, Member } from "../../src/index"
+import { create, _, is, serialize, deserialize, Member } from "../../src/index"
 import fc from "fast-check"
 
 describe("index", () => {
@@ -73,6 +73,73 @@ describe("index", () => {
           expect(deserialize<Sum>()(serialize(x))).toEqual(x)
         }),
       )
+    })
+  })
+
+  describe("is", () => {
+    type T =
+      | Member<"Foo">
+      | Member<"Bar", string>
+      | Member<"Baz", ReadonlyArray<number>>
+    const T = create<T>()
+    const f = is<T>()
+
+    it("parses according to provided refinement", () => {
+      expect(f("Foo")((x): x is null => x === null)(T.mk.Foo)).toBe(true)
+
+      expect(
+        f("Bar")((x): x is string => typeof x === "string")(T.mk.Bar("ciao")),
+      ).toBe(true)
+
+      expect(
+        f("Baz")(
+          (x): x is ReadonlyArray<number> =>
+            Array.isArray(x) && x.every(y => typeof y === "number"),
+        )(T.mk.Baz([1, 2, 3])),
+      ).toBe(true)
+    })
+
+    it("fails if refinement fails", () => {
+      expect(f("Foo")((x): x is null => false)(T.mk.Foo)).toBe(false)
+    })
+
+    it("fails bad input key", () => {
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        f("Food" as any)((x): x is null => x === null)(T.mk.Foo),
+      ).toBe(false)
+    })
+
+    it("fails wholly bad data", () => {
+      const g = f("Foo")((x): x is null => x === null)
+
+      expect(g(undefined)).toBe(false)
+      expect(g(null)).toBe(false)
+      expect(g("Foo")).toBe(false)
+      expect(g(["Foo", null])).toBe(false)
+      expect(g({ Foo: "Foo" })).toBe(false)
+    })
+
+    it("fails bad parsed key", () => {
+      type U = Member<"NotFoo">
+      const U = create<U>()
+
+      expect(f("Foo")((x): x is null => x === null)(U.mk.NotFoo)).toBe(false)
+    })
+
+    it("fails bad parsed value", () => {
+      type U = Member<"Foo", string>
+      const U = create<U>()
+
+      expect(f("Foo")((x): x is null => x === null)(U.mk.Foo("not null"))).toBe(
+        false,
+      )
+    })
+
+    it("tolerates excess properties", () => {
+      expect(
+        f("Foo")((x): x is null => x === null)({ ...T.mk.Foo, excess: true }),
+      ).toBe(true)
     })
   })
 })


### PR DESCRIPTION
Thinking of how best to tackle https://github.com/unsplash/sum-types-io-ts/pull/15 going forwards I landed here. In that specific case this could be utilised something like:

```ts
const unknownSerialize = flow(O.fromPredicate(Sum.is<A>()(k)(f)), O.map(Sum.serialize))
```