### PR TITLE
Fix `matchXW` failed pattern match when return value is `undefined`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -256,13 +256,11 @@ const mkMatchXW =
   <C extends B[keyof B]>(x: A): C => {
     const tag = x[tagKey] as Tag<A>
 
-    const g = fs[tag]
     // eslint-disable-next-line functional/no-conditional-statement, @typescript-eslint/no-unsafe-return
-    if (g !== undefined) return g as C
+    if (tag in fs) return fs[tag] as C
 
-    const h = (fs as CasesXWildcard<A, B>)[_]
     // eslint-disable-next-line functional/no-conditional-statement, @typescript-eslint/no-unsafe-return
-    if (h !== undefined) return h as C
+    if (_ in fs) return (fs as CasesXWildcard<A, B>)[_] as C
 
     // eslint-disable-next-line functional/no-throw-statement
     throw new Error(`Failed to pattern match against tag "${tag}".`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,10 +257,11 @@ const mkMatchXW =
     const tag = x[tagKey] as Tag<A>
 
     // eslint-disable-next-line functional/no-conditional-statement, @typescript-eslint/no-unsafe-return
-    if (tag in fs) return fs[tag] as C
+    if (Object.prototype.hasOwnProperty.call(fs, tag)) return fs[tag] as C
 
     // eslint-disable-next-line functional/no-conditional-statement, @typescript-eslint/no-unsafe-return
-    if (_ in fs) return (fs as CasesXWildcard<A, B>)[_] as C
+    if (Object.prototype.hasOwnProperty.call(fs, _))
+      return (fs as CasesXWildcard<A, B>)[_] as C
 
     // eslint-disable-next-line functional/no-throw-statement
     throw new Error(`Failed to pattern match against tag "${tag}".`)

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -84,6 +84,19 @@ describe("index", () => {
         expect(f(Weather.mk.Sun)).toBe("didn't rain")
       })
 
+      it("matchX allow undefined value", () => {
+        type T = Member<"A"> | Member<"B">
+        const T = create<T>()
+
+        const f = T.matchX({
+          A: undefined,
+          [_]: undefined,
+        })
+
+        expect(f(T.mk.A)).toBe(undefined)
+        expect(f(T.mk.B)).toBe(undefined)
+      })
+
       it("matchXW", () => {
         const f = Weather.matchXW({
           Rain: "rained",

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -99,18 +99,18 @@ describe("index", () => {
         expect(f(Weather.mk.Sun)).toBeNull()
       })
 
-      it('matchXW allow undefined value', () => {
-        type T = Member<'A'> | Member<'B'>
+      it("matchXW allow undefined value", () => {
+        type T = Member<"A"> | Member<"B">
         const T = create<T>()
 
         const f = T.matchXW({
           A: undefined,
-          [_]: undefined
-        });
+          [_]: undefined,
+        })
 
-        expect(f(T.mk.A)).toBe(undefined);
-        expect(f(T.mk.B)).toBe(undefined);
-      });
+        expect(f(T.mk.A)).toBe(undefined)
+        expect(f(T.mk.B)).toBe(undefined)
+      })
     })
   })
 

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -85,7 +85,7 @@ describe("index", () => {
       })
 
       it("matchX allow undefined value", () => {
-        type T = Member<"A"> | Member<"B">
+        type T = Member<"A"> | Member<"B"> | Member<"toString">
         const T = create<T>()
 
         const f = T.matchX({
@@ -95,6 +95,9 @@ describe("index", () => {
 
         expect(f(T.mk.A)).toBe(undefined)
         expect(f(T.mk.B)).toBe(undefined)
+        // Check that `toString` does not match an object prototype function
+        // This check would fail when the `in` operator is used instead of `hasOwnProperty`.
+        expect(f(T.mk.toString)).toBe(undefined)
       })
 
       it("matchXW", () => {
@@ -113,7 +116,7 @@ describe("index", () => {
       })
 
       it("matchXW allow undefined value", () => {
-        type T = Member<"A"> | Member<"B">
+        type T = Member<"A"> | Member<"B"> | Member<"toString">
         const T = create<T>()
 
         const f = T.matchXW({
@@ -123,6 +126,9 @@ describe("index", () => {
 
         expect(f(T.mk.A)).toBe(undefined)
         expect(f(T.mk.B)).toBe(undefined)
+        // Check that `toString` does not match an object prototype function.
+        // This check would fail when the `in` operator is used instead of `hasOwnProperty`.
+        expect(f(T.mk.toString)).toBe(undefined)
       })
     })
   })

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -98,6 +98,19 @@ describe("index", () => {
 
         expect(f(Weather.mk.Sun)).toBeNull()
       })
+
+      it('matchXW allow undefined value', () => {
+        type T = Member<'A'> | Member<'B'>
+        const T = create<T>()
+
+        const f = T.matchXW({
+          A: undefined,
+          [_]: undefined
+        });
+
+        expect(f(T.mk.A)).toBe(undefined);
+        expect(f(T.mk.B)).toBe(undefined);
+      });
     })
   })
 


### PR DESCRIPTION
Currently it is not possible to use `undefined`  as return value for `matchXW`. This PR solves this use by using the `in` operator to check for the existence of a `tag` instead of comparing with `undefined`.